### PR TITLE
fix: remove clear() and update Validation component to use useEffect() instead

### DIFF
--- a/nr-reports-builder-nerdpack/package.json
+++ b/nr-reports-builder-nerdpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-builder",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "sdewitt@newrelic.com",
   "description": "Nerdpack for building scheduled reports.",
   "license": "Apache-2.0",

--- a/nr-reports-builder-nerdpack/src/components/screens/edit-report/index.js
+++ b/nr-reports-builder-nerdpack/src/components/screens/edit-report/index.js
@@ -51,8 +51,8 @@ function reportToFormState(report) {
     type: report.query ? (
       SYMBOLS.REPORT_TYPES.QUERY
     ) : SYMBOLS.REPORT_TYPES.DASHBOARD,
-    query: report.query,
-    accountIds: report.accountIds,
+    query: report.query || null,
+    accountIds: report.accountIds || null,
     lastModifiedDate: report.lastModifiedDate,
     publishConfigs: report.publishConfigs ? clone(report.publishConfigs) : [],
     metadata: report.metadata || newReportMetadata(),

--- a/nr-reports-builder-nerdpack/src/contexts/form/index.js
+++ b/nr-reports-builder-nerdpack/src/contexts/form/index.js
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react'
@@ -53,9 +54,10 @@ export class Validator {
 export function Validation({ name, validation, children }) {
   const { validator } = useContext(FormContext)
 
-  useMemo(() => {
+  useEffect(() => {
     validator.addValidator(name, validation)
-  }, [])
+    return () => validator.removeValidator(name, validation)
+  })
 
   return children
 }
@@ -90,8 +92,6 @@ function FormProvider({ initFormState, children }) {
 
       setFormState({ ...formState, ...result })
     }, [formState, setFormState, validator])
-
-  validator.clear()
 
   return (
     <FormContext.Provider value={{

--- a/nr-reports-cli/package.json
+++ b/nr-reports-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-cli",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "sdewitt@newrelic.com",
   "description": "The New Relic Reports CLI runner.",
   "license": "Apache-2.0",

--- a/nr-reports-core/package.json
+++ b/nr-reports-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-core",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "sdewitt@newrelic.com",
   "description": "The New Relic Reports core engine.",
   "license": "Apache-2.0",

--- a/nr-reports-lambda/package.json
+++ b/nr-reports-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-lambda",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "sdewitt@newrelic.com",
   "description": "The New Relic Reports lambda runner.",
   "license": "Apache-2.0",

--- a/nr-reports-scheduler/package.json
+++ b/nr-reports-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-scheduler",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "sdewitt@newrelic.com",
   "description": "Scheduler module for syncing and running scheduled reports.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "sdewitt@newrelic.com",
   "description": "New Relic Reports is a report generation and automation framework for New Relic.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Updated `Validation` component to use `useEffect()` to automatically call `addValidator()` and `removeValidator()` and removed the hackier (and broken) solution of calling `validator.clear()` in the `FormProvider`.