### PR TITLE
fix: remove leading - on email/slack channel FormField styling

### DIFF
--- a/nr-reports-builder-nerdpack/package.json
+++ b/nr-reports-builder-nerdpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-builder",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "sdewitt@newrelic.com",
   "description": "Nerdpack for building scheduled reports.",
   "license": "Apache-2.0",

--- a/nr-reports-builder-nerdpack/src/components/email-channel-form/styles.scss
+++ b/nr-reports-builder-nerdpack/src/components/email-channel-form/styles.scss
@@ -1,5 +1,5 @@
 .email-channel-form {
-    div[class*="-wnd-FormField "] {
+    div[class*="wnd-FormField "] {
         width: 90%;
     }
 }

--- a/nr-reports-builder-nerdpack/src/components/slack-channel-form/styles.scss
+++ b/nr-reports-builder-nerdpack/src/components/slack-channel-form/styles.scss
@@ -1,5 +1,5 @@
 .slack-channel-form {
-    div[class*="-wnd-FormField "] {
+    div[class*="wnd-FormField "] {
         width: 90%;
     }
 }

--- a/nr-reports-cli/package.json
+++ b/nr-reports-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-cli",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "sdewitt@newrelic.com",
   "description": "The New Relic Reports CLI runner.",
   "license": "Apache-2.0",

--- a/nr-reports-core/package.json
+++ b/nr-reports-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-core",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "sdewitt@newrelic.com",
   "description": "The New Relic Reports core engine.",
   "license": "Apache-2.0",

--- a/nr-reports-lambda/package.json
+++ b/nr-reports-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-lambda",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "sdewitt@newrelic.com",
   "description": "The New Relic Reports lambda runner.",
   "license": "Apache-2.0",

--- a/nr-reports-scheduler/package.json
+++ b/nr-reports-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports-scheduler",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "sdewitt@newrelic.com",
   "description": "Scheduler module for syncing and running scheduled reports.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nr-reports",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "sdewitt@newrelic.com",
   "description": "New Relic Reports is a report generation and automation framework for New Relic.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Removed the `-` from the `wnd-FormField ` styling in `styles.scss` for the `email-channel-form` and `slack-channel-form` components.  The NR1 UI no longer seems to have prefixes on it's styles which cause this to break.