### PR TITLE
Prevent override of safe filters in templates

### DIFF
--- a/nr-reports-core/lib/template-engines/nunjucks/extensions/nrql-extension.js
+++ b/nr-reports-core/lib/template-engines/nunjucks/extensions/nrql-extension.js
@@ -116,7 +116,7 @@ function NrqlExtension() {
           return
         }
 
-        callback(null, src)
+        callback(null, new nunjucks.runtime.SafeString(src))
       })
     } catch (err) {
       handleError(context, err, errorBody, callback)


### PR DESCRIPTION
Setting the src to a SafeString when passed to the callback will prevent previously explicitly unescaped text from being escaped. 

With this in place, you can do something like:

```
{%- nrql query, accountId -%}
  {% set rows %}
    {%- for item in result %}
      <tr>
        <td>{{ item.facet }}</td>
        <td>{{ item.value }}</td>
      </tr>
     {%- endfor -%}
   {% endset %}
   {{ rows | safe }}
{%- endnrql -%}
```

And get valid html output. Without the safe filter, the html output will be escaped.