### PR TITLE
fix: do not require SOURCE_NERDLET_ID when running reports; use the catalog UUID by default.

### DIFF
--- a/nr-reports-quartz-scheduler/src/main/java/com/newrelic/labs/reports/RunReportJob.java
+++ b/nr-reports-quartz-scheduler/src/main/java/com/newrelic/labs/reports/RunReportJob.java
@@ -39,12 +39,14 @@ public class RunReportJob implements Job {
 				throw new RunReportException("missing api key");
 			}
 
-			String nerdletPackageId = this.util.getenv(
+			String nerdletPackageId = Util.REPORTS_BUILDER_NERDPACK_ID;
+			String sourceNerdletId = this.util.getenv(
 				"SOURCE_NERDLET_ID"
 			);
 
-			if (nerdletPackageId == null || nerdletPackageId.isEmpty()) {
-				throw new RunReportException("missing source nerdlet ID");
+			if (sourceNerdletId != null && !sourceNerdletId.isEmpty()) {
+				LOGGER.finest("Using a custom nerdpack ID for sourceNerdletId");
+				nerdletPackageId = sourceNerdletId;
 			}
 
 			String region = this.util.getenv(

--- a/nr-reports-quartz-scheduler/src/main/java/com/newrelic/labs/reports/Util.java
+++ b/nr-reports-quartz-scheduler/src/main/java/com/newrelic/labs/reports/Util.java
@@ -43,7 +43,7 @@ public class Util {
 		Logger.getLogger(Util.class.getName());
 	private static final Util INSTANCE = new Util();
 
-	private static final String REPORTS_BUILDER_NERDPACK_ID =
+	public static final String REPORTS_BUILDER_NERDPACK_ID =
 		"c7c1d343-e073-41d5-9b2b-5987f403aec1";
 
 	private Util() {}


### PR DESCRIPTION
**Fixes:**
* In the Java Scheduler, when setting up the environment that is used to spawn the Node report run, do not require `SOURCE_NERDLET_ID` to be set.  Use the catalog nerdlet UUID by default.